### PR TITLE
feat(agent): web.search / web.fetch / web.open tools

### DIFF
--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
     "pydantic-settings>=2.6",
     "websockets>=13",
     "apscheduler>=3.11.2",
+    "selectolax>=0.4.7",
+    "httpx>=0.27",
 ]
 
 [project.scripts]
@@ -19,7 +21,6 @@ agent = "agent.__main__:main"
 dev = [
     "pytest>=8",
     "pytest-asyncio>=0.24",
-    "httpx>=0.27",
     "ruff>=0.8",
     "mypy>=1.13",
 ]

--- a/agent/src/agent/factory.py
+++ b/agent/src/agent/factory.py
@@ -25,6 +25,7 @@ from agent.tools import ToolRegistry
 from agent.tools.ask_user import AskUserTool
 from agent.tools.memory_tools import MemorySearchTool, MemoryUpsertTool
 from agent.tools.schedule_tools import ScheduleRegisterTool
+from agent.tools.web_tools import WebFetchTool, WebOpenTool, WebSearchTool
 from agent.voice.tts_voicevox import VoicevoxTTS
 
 
@@ -65,6 +66,9 @@ def build_app(token: str, *, settings: Settings | None = None) -> FastAPI:
     registry.register(MemorySearchTool(search))
     registry.register(MemoryUpsertTool(core))
     registry.register(AskUserTool())
+    registry.register(WebSearchTool())
+    registry.register(WebFetchTool())
+    registry.register(WebOpenTool())
 
     # TTS: connect to VOICEVOX if reachable, or spawn from binary.
     tts: VoicevoxTTS | None = None

--- a/agent/src/agent/integrations/__init__.py
+++ b/agent/src/agent/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""External service integrations (search providers, browsers, etc.)."""

--- a/agent/src/agent/integrations/ddg_search.py
+++ b/agent/src/agent/integrations/ddg_search.py
@@ -1,0 +1,100 @@
+"""DuckDuckGo HTML search provider.
+
+Hits the html.duckduckgo.com endpoint that DuckDuckGo provides
+specifically for scrape-friendly access. No API key, no rate-limiting
+headaches as long as we behave like a normal browser.
+
+The HTML contract is intentionally narrow — class names like
+``.result__title`` / ``.result__snippet`` / ``.result__url`` are the
+documented selectors. They've been stable for years; if DDG changes
+them this module is the single place to update.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+from selectolax.parser import HTMLParser
+
+_DDG_URL = "https://html.duckduckgo.com/html/"
+_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/124.0.0.0 Safari/537.36"
+)
+
+
+@dataclass(frozen=True)
+class SearchHit:
+    title: str
+    url: str
+    snippet: str
+
+
+class WebSearchProvider(Protocol):
+    async def search(self, query: str, limit: int = 5) -> list[SearchHit]: ...
+
+
+def _unwrap_ddg_redirect(href: str) -> str:
+    """DDG wraps result URLs in /l/?uddg=<encoded>. Recover the real URL."""
+    if "uddg=" not in href:
+        return href
+    parsed = urlparse(href)
+    qs = parse_qs(parsed.query)
+    target = qs.get("uddg", [""])[0]
+    return target or href
+
+
+class DuckDuckGoProvider:
+    def __init__(
+        self,
+        *,
+        timeout_s: float = 10.0,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._timeout_s = timeout_s
+        self._transport = transport
+
+    def _client(self) -> httpx.AsyncClient:
+        kwargs: dict[str, object] = {
+            "timeout": self._timeout_s,
+            "headers": {"User-Agent": _USER_AGENT},
+            "follow_redirects": True,
+        }
+        if self._transport is not None:
+            kwargs["transport"] = self._transport
+        return httpx.AsyncClient(**kwargs)  # type: ignore[arg-type]
+
+    async def search(self, query: str, limit: int = 5) -> list[SearchHit]:
+        if not query.strip():
+            return []
+        async with self._client() as client:
+            resp = await client.post(_DDG_URL, data={"q": query})
+            resp.raise_for_status()
+            html = resp.text
+
+        return self._parse(html, limit)
+
+    @staticmethod
+    def _parse(html: str, limit: int) -> list[SearchHit]:
+        tree = HTMLParser(html)
+        hits: list[SearchHit] = []
+        for result in tree.css(".result"):
+            title_node = result.css_first(".result__title")
+            snippet_node = result.css_first(".result__snippet")
+            link_node = result.css_first(".result__a") or title_node
+            if not (title_node and link_node):
+                continue
+            href = link_node.attributes.get("href", "") or ""
+            url = _unwrap_ddg_redirect(href)
+            title = (title_node.text() or "").strip()
+            snippet = (snippet_node.text() if snippet_node else "").strip()
+            if not (title and url):
+                continue
+            hits.append(SearchHit(title=title, url=url, snippet=snippet))
+            if len(hits) >= limit:
+                break
+        return hits

--- a/agent/src/agent/tools/web_tools.py
+++ b/agent/src/agent/tools/web_tools.py
@@ -1,0 +1,164 @@
+"""Web tools — search, fetch, and open-in-browser.
+
+Phase scope (this commit, issue #42):
+- ``web.search`` via DuckDuckGo HTML scrape (no API key required)
+- ``web.fetch`` minimal HTTP-only implementation that returns the
+  body text. Will be replaced by a Playwright worker in a later
+  phase for JS-rendered pages and cleaner article extraction.
+- ``web.open`` uses the OS default browser via stdlib ``webbrowser``.
+  The agent cannot read the page that opens — this is a "show the
+  user something" tool, not a research tool.
+
+All three are risk=low; ``web.fetch`` returns potentially untrusted
+content, so callers should wrap the result with the
+``[UNTRUSTED source=<url>]…[/UNTRUSTED]`` envelope when injecting
+back into the LLM context (issue #44).
+"""
+
+from __future__ import annotations
+
+import webbrowser
+from typing import Any
+
+import httpx
+from selectolax.parser import HTMLParser
+
+from agent.integrations.ddg_search import DuckDuckGoProvider, WebSearchProvider
+from agent.tools.base import Tool
+
+_FETCH_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/124.0.0.0 Safari/537.36"
+)
+_FETCH_MAX_CHARS = 8000  # cap injected text so we don't blow the context window
+
+
+class WebSearchTool(Tool):
+    name = "web.search"
+    description = (
+        "DuckDuckGo でキーワード Web 検索を行う。返却は title / url / "
+        "snippet の配列。Web 上の最新情報や知らないトピックを調べたい時に使う。"
+    )
+    risk = "low"
+    requires_confirmation = False
+
+    def __init__(self, provider: WebSearchProvider | None = None) -> None:
+        self._provider = provider or DuckDuckGoProvider()
+
+    def parameters_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "required": ["query"],
+            "properties": {
+                "query": {"type": "string", "description": "検索キーワード"},
+                "limit": {
+                    "type": "integer",
+                    "default": 5,
+                    "minimum": 1,
+                    "maximum": 10,
+                },
+            },
+        }
+
+    async def execute(self, args: dict[str, Any]) -> Any:
+        query = str(args.get("query", ""))
+        limit = int(args.get("limit", 5))
+        hits = await self._provider.search(query, limit=limit)
+        return [
+            {"title": h.title, "url": h.url, "snippet": h.snippet} for h in hits
+        ]
+
+
+class WebFetchTool(Tool):
+    name = "web.fetch"
+    description = (
+        "URL を取得して本文テキストを返す。検索結果から興味あるページを開いて"
+        "中身を確認したい時に使う。HTML タグは除去され、最大 8000 文字までに切り詰める。"
+    )
+    risk = "low"
+    requires_confirmation = False
+
+    def __init__(
+        self,
+        *,
+        timeout_s: float = 15.0,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._timeout_s = timeout_s
+        self._transport = transport
+
+    def parameters_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "required": ["url"],
+            "properties": {
+                "url": {"type": "string", "description": "取得する URL (http/https)"},
+            },
+        }
+
+    def _client(self) -> httpx.AsyncClient:
+        kwargs: dict[str, object] = {
+            "timeout": self._timeout_s,
+            "headers": {"User-Agent": _FETCH_USER_AGENT},
+            "follow_redirects": True,
+        }
+        if self._transport is not None:
+            kwargs["transport"] = self._transport
+        return httpx.AsyncClient(**kwargs)  # type: ignore[arg-type]
+
+    async def execute(self, args: dict[str, Any]) -> Any:
+        url = str(args.get("url", ""))
+        if not url.startswith(("http://", "https://")):
+            return {"ok": False, "error": "URL must be http(s)://"}
+
+        async with self._client() as client:
+            resp = await client.get(url)
+        if resp.status_code >= 400:
+            return {"ok": False, "url": url, "status": resp.status_code}
+
+        text = _extract_text(resp.text)
+        if len(text) > _FETCH_MAX_CHARS:
+            text = text[:_FETCH_MAX_CHARS] + "\n…(truncated)"
+        return {"ok": True, "url": str(resp.url), "text": text}
+
+
+def _extract_text(html: str) -> str:
+    """Drop scripts / styles / nav, then return the visible text."""
+    tree = HTMLParser(html)
+    for sel in ("script", "style", "noscript", "nav", "header", "footer"):
+        for node in tree.css(sel):
+            node.decompose()
+    body = tree.css_first("body") or tree.root
+    if body is None:
+        return ""
+    raw = body.text(separator="\n")
+    # Collapse blank-line runs (DuckDuckGo / news sites have many).
+    lines = [ln.strip() for ln in raw.splitlines()]
+    return "\n".join(ln for ln in lines if ln)
+
+
+class WebOpenTool(Tool):
+    name = "web.open"
+    description = (
+        "URL をユーザーの既定ブラウザで開く。エージェントは中身を読まない。"
+        "ユーザーに直接見せたいページがある時のみ使う。"
+    )
+    risk = "low"
+    requires_confirmation = False
+
+    def parameters_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "required": ["url"],
+            "properties": {
+                "url": {"type": "string", "description": "開く URL"},
+            },
+        }
+
+    async def execute(self, args: dict[str, Any]) -> Any:
+        url = str(args.get("url", ""))
+        if not url.startswith(("http://", "https://")):
+            return {"ok": False, "error": "URL must be http(s)://"}
+        opened = webbrowser.open(url, new=2)
+        return {"ok": bool(opened), "url": url}

--- a/agent/tests/test_web_tools.py
+++ b/agent/tests/test_web_tools.py
@@ -1,0 +1,165 @@
+"""Web tool tests — DDG search parser, fetch, open."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from agent.integrations.ddg_search import DuckDuckGoProvider, _unwrap_ddg_redirect
+from agent.tools.web_tools import WebFetchTool, WebOpenTool, WebSearchTool
+
+# A small representative chunk of html.duckduckgo.com output.  Class
+# names are the documented selectors and have been stable; if DDG
+# changes the layout this fixture is the regression boundary.
+_DDG_HTML = """\
+<html><body>
+  <div class="result">
+    <a class="result__a"
+       href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fwww.rust-lang.org%2F&amp;rut=x">
+      <h2 class="result__title">The Rust Programming Language</h2>
+    </a>
+    <a class="result__url" href="https://www.rust-lang.org/">www.rust-lang.org</a>
+    <span class="result__snippet">A language empowering everyone to build reliable software.</span>
+  </div>
+  <div class="result">
+    <a class="result__a" href="https://blog.rust-lang.org/">
+      <h2 class="result__title">Rust Blog</h2>
+    </a>
+    <span class="result__snippet">Empowering everyone to build reliable software.</span>
+  </div>
+  <div class="result no-link"><span>filler without anchor — must be skipped</span></div>
+</body></html>
+"""
+
+
+def test_unwrap_ddg_redirect_decodes_target() -> None:
+    href = "//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fpath&rut=x"
+    assert _unwrap_ddg_redirect(href) == "https://example.com/path"
+
+
+def test_unwrap_ddg_redirect_passes_through_plain_url() -> None:
+    assert _unwrap_ddg_redirect("https://example.com/") == "https://example.com/"
+
+
+@pytest.mark.asyncio
+async def test_ddg_search_parses_html() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert "html.duckduckgo.com" in str(request.url)
+        return httpx.Response(200, text=_DDG_HTML)
+
+    provider = DuckDuckGoProvider(transport=httpx.MockTransport(handler))
+    hits = await provider.search("rust", limit=5)
+
+    assert len(hits) == 2
+    assert hits[0].title == "The Rust Programming Language"
+    # uddg= redirect was unwrapped
+    assert hits[0].url == "https://www.rust-lang.org/"
+    assert "reliable software" in hits[0].snippet
+    assert hits[1].title == "Rust Blog"
+
+
+@pytest.mark.asyncio
+async def test_ddg_search_respects_limit() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=_DDG_HTML)
+
+    provider = DuckDuckGoProvider(transport=httpx.MockTransport(handler))
+    hits = await provider.search("rust", limit=1)
+    assert len(hits) == 1
+
+
+@pytest.mark.asyncio
+async def test_ddg_search_empty_query_returns_empty_list() -> None:
+    transport = httpx.MockTransport(lambda _r: httpx.Response(200, text=""))
+    provider = DuckDuckGoProvider(transport=transport)
+    assert await provider.search("") == []
+    assert await provider.search("   ") == []
+
+
+@pytest.mark.asyncio
+async def test_web_search_tool_returns_dicts() -> None:
+    class FakeProvider:
+        async def search(self, query: str, limit: int = 5):
+            from agent.integrations.ddg_search import SearchHit
+
+            return [SearchHit(title="t", url="u", snippet="s")]
+
+    tool = WebSearchTool(provider=FakeProvider())
+    out = await tool.execute({"query": "x"})
+    assert out == [{"title": "t", "url": "u", "snippet": "s"}]
+
+
+def test_web_search_tool_schema_declares_required_query() -> None:
+    schema = WebSearchTool().parameters_schema()
+    assert "query" in schema["required"]
+    assert schema["properties"]["limit"]["default"] == 5
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_extracts_visible_text() -> None:
+    html = """
+    <html><head><title>t</title>
+      <script>console.log('drop me')</script>
+      <style>.x{}</style>
+    </head><body>
+      <nav>menu</nav>
+      <article>
+        <h1>Hello</h1>
+        <p>This is a paragraph.</p>
+      </article>
+      <footer>copyright</footer>
+    </body></html>
+    """
+
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=html)
+
+    tool = WebFetchTool(transport=httpx.MockTransport(handler))
+    result = await tool.execute({"url": "https://example.com/"})
+
+    assert result["ok"] is True
+    text = result["text"]
+    assert "Hello" in text
+    assert "This is a paragraph." in text
+    # script / style / nav / footer were stripped
+    assert "console.log" not in text
+    assert "menu" not in text
+    assert "copyright" not in text
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_rejects_non_http_url() -> None:
+    tool = WebFetchTool()
+    result = await tool.execute({"url": "file:///etc/passwd"})
+    assert result["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_truncates_very_long_pages() -> None:
+    big = "abcdef\n" * 5000  # ~35k chars
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=f"<html><body>{big}</body></html>")
+
+    tool = WebFetchTool(transport=httpx.MockTransport(handler))
+    result = await tool.execute({"url": "https://example.com/"})
+    assert result["ok"] is True
+    assert len(result["text"]) <= 8200  # 8000 + "(truncated)" tail
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_reports_http_errors() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, text="not found")
+
+    tool = WebFetchTool(transport=httpx.MockTransport(handler))
+    result = await tool.execute({"url": "https://example.com/missing"})
+    assert result["ok"] is False
+    assert result["status"] == 404
+
+
+@pytest.mark.asyncio
+async def test_web_open_rejects_non_http_url() -> None:
+    tool = WebOpenTool()
+    result = await tool.execute({"url": "file:///c:/secret"})
+    assert result["ok"] is False

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -82,15 +82,16 @@ source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "selectolax" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "websockets" },
 ]
 
 [package.dev-dependencies]
 dev = [
-    { name = "httpx" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -101,15 +102,16 @@ dev = [
 requires-dist = [
     { name = "apscheduler", specifier = ">=3.11.2" },
     { name = "fastapi", specifier = ">=0.115" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "pydantic-settings", specifier = ">=2.6" },
+    { name = "selectolax", specifier = ">=0.4.7" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
     { name = "websockets", specifier = ">=13" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "httpx", specifier = ">=0.27" },
     { name = "mypy", specifier = ">=1.13" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
@@ -428,6 +430,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
     { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
     { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
+]
+
+[[package]]
+name = "selectolax"
+version = "0.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/5c/bf049c4aec4c102977abcac68a90dfb1031edc225e9a754fe2c7e624a2d2/selectolax-0.4.7.tar.gz", hash = "sha256:17f7ba5a21714d450b4eea0451608a36be2bba8d327990ddbda812eb3f36fa51", size = 4822635, upload-time = "2026-03-06T09:25:15.411Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/1d/8d3db7dcc053f7f4088a826f9089324c7b37617f9caaf6a03f0ff5854bbd/selectolax-0.4.7-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8fa541a520cc6213d754ec747ebbff12fdcc5b9f6bb7615784486e18697209fb", size = 2059304, upload-time = "2026-03-06T09:24:04.861Z" },
+    { url = "https://files.pythonhosted.org/packages/42/64/de442c5056aa4f42d140556a8093bfadee72545919384cf38d6f651b75b0/selectolax-0.4.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2a0e9b1e3b1d091a0133b44b3967c79db8de73d99efe38af85bab615775aa4e8", size = 2057450, upload-time = "2026-03-06T09:24:06.25Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/42/969e084f59c845fbb304d55f8e3899ffe823f3cd78d85d083edffe772766/selectolax-0.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7134b119c011e18d1e914d5adbb8f953e391649b4af734fcec61dad691a16f59", size = 2251180, upload-time = "2026-03-06T09:24:07.536Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/1b/d8f84cb6385637cd793aad3a53618d3ee1b4329e0feb0f4db7a7f81af4da/selectolax-0.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3840b79f5f39744b95dc80e3b428cf4e49b86d8c6e9cbb3e7df3e702bf240cce", size = 2292532, upload-time = "2026-03-06T09:24:08.896Z" },
+    { url = "https://files.pythonhosted.org/packages/85/54/15c3b5d94cf969748ffcca7289245d477ef69ce30a359c5a764b0bc2226e/selectolax-0.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:eb6faf15e6cc6a7c61c04e15c3490e3f6693c98f732e531941687093de36db81", size = 2263969, upload-time = "2026-03-06T09:24:10.556Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4f/fa4125a9a92b2a15a3b332592270e003e9092bb97c3d6c3a7f2714b4c507/selectolax-0.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3799b39d60266f7d4c48f322fac8eaecc6dec38f4342d6d3b17085d11815bcb4", size = 2298497, upload-time = "2026-03-06T09:24:11.919Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9d/fef3b7d4f8da87762574ea20ff9612485639d6b0a9b7d3839738d8ced105/selectolax-0.4.7-cp312-cp312-win32.whl", hash = "sha256:88344c8764f3a2fbcae2fd2353201c330920943c2da34a16e9b063f918deb7d6", size = 1735965, upload-time = "2026-03-06T09:24:13.407Z" },
+    { url = "https://files.pythonhosted.org/packages/31/25/5b893677a0acfc579d9ccb3f01204c4554ba533db5c144cc3b18e33e347b/selectolax-0.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:00953c3c6a7e4dfd990a5651315b713d50131706c239c1f1c5b6d4a75a11975a", size = 1833805, upload-time = "2026-03-06T09:24:14.726Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ad/bb94f409f33871b6d9b3b4d56fb82d14d9b2fd2e7657f32c25a35167187e/selectolax-0.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:e6b8d0f7cbdc6ca5cbf52dbd37f70c170184040499ac59a23409724724276784", size = 1783620, upload-time = "2026-03-06T09:24:16.062Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- DuckDuckGo HTML 検索プロバイダ (`agent/integrations/ddg_search.py`) と 3 つの Web tool (`web.search` / `web.fetch` / `web.open`) を追加
- 既存の tool registry / TurnLoop に登録、API キー不要で動作

## 実装範囲
- `WebSearchTool`: DDG で `query` 検索 → `[{title, url, snippet}]` を返す
- `WebFetchTool`: 任意の http(s) URL を取得 → 本文テキスト抽出 (script/style/nav/header/footer 除去) → 8000 文字キャップ
- `WebOpenTool`: ユーザーの既定ブラウザで URL を開く (agent は中身を読まない)
- 全部 risk=low、承認不要

## 検証結果

### 単体テスト
- `agent/tests/test_web_tools.py` 12 件追加 (DDG パース / redirect 展開 / fetch 文字列抽出 / URL スキームチェック / 切り詰め / HTTP エラー)
- 全テスト 40 passed, 1 skipped (live)、ruff / mypy --strict 全緑

### LLM 経由 E2E (Qwen3.5-9B + Qwen3.5-4B 両方で実走確認)

**Qwen3.5-9B**: 「Search the web for the latest Rust release.」
- LLM が `web.search` を 1 回呼び出し: `query: "latest Rust release 2026"`
- DDG 経由で Rust Release Notes を取得
- 検索結果を要約して構造化日本語応答 (Stable 1.95.0 / Beta 1.96.0 / Nightly 1.97.0、CVE 情報込み)
- TTS 4.36MB 合成成功

**Qwen3.5-4B**: 同じプロンプト
- LLM が `web.search` → さらに `web.fetch("https://releases.rs/")` を **自動チェーン**
- fetch 結果から "Stable: 1.95.0 / Beta: 1.96.0 (28 May, 2026, 30 days left)" を抽出
- 4B でも tool calling パイプラインが正常動作することを確認

### 直接実行 (live DDG endpoint)
- `DuckDuckGoProvider().search("Rust programming language")` を Python から直接実行
- 実 HTML をパースして Rust 公式 / Wikipedia 等の organic 結果を取得確認
- (sponsored ad は messy なまま通る — 広告フィルタは別 issue で polish 予定)

## 残課題 (別 issue で対応)
- 広告フィルタ (DDG の sponsored result はそのまま混じる)
- `web.fetch` を Playwright worker + readability.js に置き換え (JS 描画ページ対応)
- `[UNTRUSTED]` タグ付け (#44 と統合)
- TTS WAV が大きい場合の WS フレーム分割 (副次的に発見、別件)

Closes #42