### PR TITLE
feat: sentence-level streaming TTS

### DIFF
--- a/agent/src/agent/interface/server.py
+++ b/agent/src/agent/interface/server.py
@@ -102,6 +102,8 @@ async def _dispatch(
 
     if method == "session.send_text":
         text = str(params.get("text", ""))
+        # Per-turn TTS sequence counter (boxed so the inner loop can mutate).
+        tts_seq_counter = [0]
         if turn_loop is None:
             # Phase 0 fallback for tests and bare-bones smoke checks.
             await _send_say(ws, f"echo: {text}", is_thinking=False)
@@ -137,10 +139,15 @@ async def _dispatch(
                         },
                     )
                 elif evt.kind == "tts":
-                    # Send TTS audio as a binary WS frame.
-                    # Tag byte 0x02 = tts, then 8 bytes seq (0 for now),
-                    # then WAV payload.
-                    tag = b"\x02" + b"\x00" * 8 + evt.audio_wav
+                    # Send TTS audio as a binary WS frame:
+                    #   tag (1 byte 0x02) + seq (8 bytes BE u64) + WAV
+                    # Each sentence is one frame (streaming TTS, see
+                    # SentenceSplitter). The client concatenates by
+                    # seq order; out-of-order frames stay rare since
+                    # synthesis is awaited sequentially.
+                    seq = tts_seq_counter[0]
+                    tts_seq_counter[0] += 1
+                    tag = b"\x02" + seq.to_bytes(8, "big") + evt.audio_wav
                     await ws.send_bytes(tag)
 
         if req_id is not None:

--- a/agent/src/agent/orchestrator/turn_loop.py
+++ b/agent/src/agent/orchestrator/turn_loop.py
@@ -29,6 +29,7 @@ from agent.orchestrator.prompt import build_messages, build_system_prompt
 from agent.orchestrator.session import SessionManager
 from agent.tools.base import ToolResult
 from agent.tools.registry import ToolRegistry
+from agent.voice.sentence_splitter import SentenceSplitter
 from agent.voice.tts_voicevox import VoicevoxTTS
 
 MAX_TOOL_STEPS = 5
@@ -123,6 +124,7 @@ class TurnLoop:
             main_buf: list[str] = []
             thinking_buf: list[str] = []
             tool_calls: list[ToolCallDelta] = []
+            splitter = SentenceSplitter()
 
             async for chunk in self._llm.chat_stream(
                 prompt, tools=tool_schemas, thinking=False
@@ -141,6 +143,22 @@ class TurnLoop:
                     text=chunk.text,
                     is_thinking=chunk.is_thinking,
                 )
+                # Streaming TTS: synthesize each completed sentence as
+                # it arrives. Each WAV is ~tens-of-KB instead of one
+                # multi-MB blob at the end, which both improves
+                # perceived latency and stays under any reasonable
+                # WS frame size limit.
+                if not chunk.is_thinking and self._tts is not None:
+                    for sentence in splitter.feed(chunk.text):
+                        async for ev in self._synthesize(sentence):
+                            yield ev
+
+            # Flush any tail fragment (no terminator at end).
+            if self._tts is not None:
+                tail = splitter.flush()
+                if tail:
+                    async for ev in self._synthesize(tail):
+                        yield ev
 
             # If no tool calls, we're done.
             if not tool_calls:
@@ -234,19 +252,22 @@ class TurnLoop:
         final_text = "".join(main_buf).strip()
         if final_text:
             stored = self._sessions.append_message(session.id, "assistant", final_text)
-
-            # TTS before end so the client can play audio while
-            # rendering the final bubble. agent.say_end is the
-            # last event — clients stop listening after it.
-            if self._tts is not None:
-                try:
-                    wav = await self._tts.synthesize(final_text)
-                    yield TTSEvent(audio_wav=wav)
-                except Exception as e:
-                    import sys
-
-                    sys.stderr.write(f"[voice] TTS synthesis failed: {e}\n")
-
             yield SayEvent(kind="end", message_id=str(stored.id))
         else:
             yield SayEvent(kind="end", message_id="")
+
+    async def _synthesize(self, text: str) -> AsyncIterator[TTSEvent]:
+        """Run VOICEVOX on a single sentence and yield a TTSEvent.
+
+        Failures are logged but never raise — TTS is best-effort,
+        text streaming must continue regardless.
+        """
+        if self._tts is None or not text:
+            return
+        try:
+            wav = await self._tts.synthesize(text)
+            yield TTSEvent(audio_wav=wav)
+        except Exception as e:
+            import sys
+
+            sys.stderr.write(f"[voice] TTS synthesis failed for {text[:30]!r}: {e}\n")

--- a/agent/src/agent/voice/sentence_splitter.py
+++ b/agent/src/agent/voice/sentence_splitter.py
@@ -1,0 +1,56 @@
+"""Incremental sentence splitter for streaming TTS.
+
+The orchestrator streams LLM tokens as they arrive. We feed each
+delta into this splitter, which buffers characters until it hits a
+sentence boundary, then yields the complete sentence (which the
+TTS engine can immediately synthesize).
+
+Boundaries: Japanese 「。」「！」「？」 + English ``. ! ?`` followed
+by whitespace or end-of-buffer. Newlines also count so list items
+get spoken one at a time.
+
+Short fragments (under MIN_CHARS) are merged into the next sentence
+to avoid VOICEVOX-spawn-overhead per token.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+# Japanese full-stop, exclamation, question + ASCII counterparts.
+_TERMINATORS = set("。！？.!?")
+_MIN_CHARS = 5  # don't synthesize fragments shorter than this
+
+
+class SentenceSplitter:
+    def __init__(self, *, min_chars: int = _MIN_CHARS) -> None:
+        self._buf: list[str] = []
+        self._buf_len: int = 0
+        self._min_chars = min_chars
+
+    def feed(self, text: str) -> Iterator[str]:
+        """Yield complete sentences as they cross a boundary."""
+        if not text:
+            return
+        for ch in text:
+            self._buf.append(ch)
+            self._buf_len += 1
+            if ch in _TERMINATORS and self._buf_len >= self._min_chars:
+                yield "".join(self._buf).strip()
+                self._buf.clear()
+                self._buf_len = 0
+            elif ch == "\n" and self._buf_len >= self._min_chars:
+                fragment = "".join(self._buf).strip()
+                self._buf.clear()
+                self._buf_len = 0
+                if fragment:
+                    yield fragment
+
+    def flush(self) -> str:
+        """Return whatever is left in the buffer at stream end."""
+        if not self._buf:
+            return ""
+        out = "".join(self._buf).strip()
+        self._buf.clear()
+        self._buf_len = 0
+        return out

--- a/agent/tests/test_sentence_splitter.py
+++ b/agent/tests/test_sentence_splitter.py
@@ -1,0 +1,77 @@
+"""SentenceSplitter — incremental sentence boundary detection."""
+
+from __future__ import annotations
+
+from agent.voice.sentence_splitter import SentenceSplitter
+
+
+def _drive(splitter: SentenceSplitter, chunks: list[str]) -> tuple[list[str], str]:
+    out: list[str] = []
+    for c in chunks:
+        out.extend(splitter.feed(c))
+    return out, splitter.flush()
+
+
+def test_single_japanese_sentence_emitted_on_terminator() -> None:
+    sentences, tail = _drive(SentenceSplitter(), ["こんにちは、ぼくはずんだもんなのだ。"])
+    assert sentences == ["こんにちは、ぼくはずんだもんなのだ。"]
+    assert tail == ""
+
+
+def test_chunked_input_is_buffered_until_terminator() -> None:
+    # LLM streams character-by-character.
+    sentences, tail = _drive(
+        SentenceSplitter(),
+        ["こ", "ん", "に", "ち", "は", "、", "元", "気", "?"],
+    )
+    assert sentences == ["こんにちは、元気?"]
+    assert tail == ""
+
+
+def test_multiple_sentences_emitted_in_order() -> None:
+    sentences, tail = _drive(
+        SentenceSplitter(),
+        ["最初の文です。", "次の文だよ！", "三つ目の質問は?"],
+    )
+    assert sentences == ["最初の文です。", "次の文だよ！", "三つ目の質問は?"]
+    assert tail == ""
+
+
+def test_short_fragment_below_min_chars_is_held() -> None:
+    # "はい。" is 3 chars, below default min 8 — should not flush yet.
+    sentences, tail = _drive(SentenceSplitter(), ["はい。", "本当に短いね。"])
+    # The "はい。" terminator is ignored because length < min_chars.
+    # The next terminator after enough chars triggers a flush.
+    assert sentences == ["はい。本当に短いね。"]
+    assert tail == ""
+
+
+def test_newline_breaks_list_items() -> None:
+    sentences, tail = _drive(
+        SentenceSplitter(),
+        ["- 項目その一です\n", "- 項目その二は別の文\n", "- 三つ目最後"],
+    )
+    assert "- 項目その一です" in sentences
+    assert "- 項目その二は別の文" in sentences
+    assert tail == "- 三つ目最後"
+
+
+def test_flush_returns_unterminated_tail() -> None:
+    sp = SentenceSplitter()
+    sentences = list(sp.feed("途中で切れて"))
+    assert sentences == []
+    assert sp.flush() == "途中で切れて"
+
+
+def test_flush_empty_when_buffer_empty() -> None:
+    sp = SentenceSplitter()
+    list(sp.feed("最初の文。"))  # consume
+    assert sp.flush() == ""
+
+
+def test_english_terminators() -> None:
+    sentences, _ = _drive(
+        SentenceSplitter(),
+        ["This is a sentence. ", "Another one! ", "And a question?"],
+    )
+    assert sentences == ["This is a sentence.", "Another one!", "And a question?"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -83,7 +83,12 @@ export function App() {
         onBinary: (data: ArrayBuffer) => {
           const view = new Uint8Array(data);
           if (view[0] === 0x02 && view.length > 9) {
-            playWav(data.slice(9)).catch(console.error);
+            // Bytes 1..8 are the BE u64 sequence number; we only
+            // need the low 32 bits (32-bit Number is plenty for
+            // per-turn sequencing).
+            const seq =
+              (view[5] << 24) | (view[6] << 16) | (view[7] << 8) | view[8];
+            playWav(data.slice(9), seq).catch(console.error);
           }
         },
       });

--- a/frontend/src/features/voice/ttsPlayer.ts
+++ b/frontend/src/features/voice/ttsPlayer.ts
@@ -1,12 +1,23 @@
 /**
- * Plays WAV audio received as binary WebSocket frames.
+ * Plays WAV audio chunks received as binary WebSocket frames.
  *
- * The daemon sends TTS frames with tag byte 0x02, 8-byte seq, then
- * raw WAV payload. This module decodes the WAV and plays it through
- * the Web Audio API.
+ * Frame format from the daemon:
+ *   byte 0      : tag (0x02 = TTS)
+ *   bytes 1..8  : seq (BE u64) — increments per turn
+ *   bytes 9..   : WAV payload
+ *
+ * The daemon now streams TTS one sentence per frame (issue #53), so a
+ * single agent reply emits N frames in sequence. We schedule each new
+ * chunk to start where the previous one ends, giving the user
+ * gap-free playback even though chunks arrive at synthesis speed.
+ *
+ * Resets after a sufficiently long quiet period so a new turn starts
+ * playback immediately.
  */
 
 let audioCtx: AudioContext | null = null;
+let nextStartTime = 0;
+let lastSeq = -1;
 
 function getAudioContext(): AudioContext {
   if (!audioCtx) {
@@ -15,11 +26,24 @@ function getAudioContext(): AudioContext {
   return audioCtx;
 }
 
-export async function playWav(wavBytes: ArrayBuffer): Promise<void> {
+export async function playWav(wavBytes: ArrayBuffer, seq?: number): Promise<void> {
   const ctx = getAudioContext();
   const buffer = await ctx.decodeAudioData(wavBytes);
+
+  // If this is the first chunk of a new turn (seq decreased or
+  // playback queue has fully drained), start at "now".
+  const now = ctx.currentTime;
+  if (seq !== undefined && seq <= lastSeq) {
+    nextStartTime = now;
+  }
+  if (nextStartTime < now) {
+    nextStartTime = now;
+  }
+
   const source = ctx.createBufferSource();
   source.buffer = buffer;
   source.connect(ctx.destination);
-  source.start(0);
+  source.start(nextStartTime);
+  nextStartTime += buffer.duration;
+  if (seq !== undefined) lastSeq = seq;
 }


### PR DESCRIPTION
Closes #53

## Summary
LLM 応答を文単位 (`。！？.!?`) で区切り、各文を VOICEVOX で逐次合成して個別の WS binary frame で送る。

## なぜ
- 長い応答 (300字以上) で WAV が ~4MB になり、Python `websockets` 既定 max_size 1MB を超えてクライアントで `ConnectionClosedError 1009` を起こしていた
- 合成が全文揃ってからの一括だったので、ユーザーは応答開始まで秒単位待たされていた

## 変更点

### Agent
- `voice/sentence_splitter.py` 新規: 増分でストリームを受けて文境界を検出。短すぎる断片 (「はい。」等) は次文と merge。日英の終端文字 + 改行 (リスト項目用) 対応
- `orchestrator/turn_loop.py`: LLM の各 chunk を splitter に流し、文ができ次第 VoicevoxTTS で合成 → TTSEvent yield。stream 末尾の tail も flush
- `interface/server.py`: TTS frame の seq を実 u64 連番に (placeholder 0 だった)

### Frontend
- `features/voice/ttsPlayer.ts`: 各 chunk を `AudioContext.currentTime + buffer.duration` でスケジュールして gap-free 再生。seq 減少を turn 切替として検出してリセット
- `App.tsx` onBinary: bytes 1..8 から seq 抽出して playWav に渡す

## 検証

### 単体テスト
- SentenceSplitter 8 件追加 (日本語/英語/chunk/short/newline/flush)
- agent 48 passed, 1 skipped (40 → 48)
- frontend 21 passed (変化なし)、typecheck 緑

### LLM 経由 E2E (Qwen3.5-4B + VOICEVOX live)
プロンプト: 「こんにちは。今日の天気を3文くらいで教えて。」
- TTS 10 フレーム送信 (seq 0-9 連続)
- 各 frame サイズ: **60-412 KB** (旧実装では 4MB+ で frame size エラー)
- 合計 2.2MB を frame size エラー無しで完走
- 各文を await VoicevoxTTS で逐次合成、frontend で gap-free 再生

## 副次効果
- レイテンシ大幅改善: 最初の文だけ合成すれば再生開始 (旧: 全文合成完了まで無音)
- WS frame size 上限の余裕復活