### PR TITLE
feat(frontend): window dragging + emotion changes (idle/drag)

### DIFF
--- a/frontend/src-tauri/capabilities/default.json
+++ b/frontend/src-tauri/capabilities/default.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "Default capability for the main window.",
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "core:window:allow-start-dragging"
+  ]
+}

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -19,7 +19,8 @@
         "decorations": false,
         "alwaysOnTop": true,
         "resizable": false,
-        "skipTaskbar": true
+        "skipTaskbar": true,
+        "dragDropEnabled": true
       }
     ],
     "security": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,11 +10,13 @@ import {
 } from "./store";
 
 const VALID_EMOTIONS: ReadonlySet<Emotion> = new Set([
-  "neutral", "smile", "think", "surprise", "sad", "angry",
+  "neutral", "smile", "think", "surprise", "sad", "angry", "happy",
 ]);
 function isEmotion(v: unknown): v is Emotion {
   return typeof v === "string" && VALID_EMOTIONS.has(v as Emotion);
 }
+
+const IDLE_HAPPY_DELAY_MS = 60_000;
 
 export function App() {
   const setStatus = useConnectionStore((s) => s.setState);
@@ -24,18 +26,97 @@ export function App() {
 
   const [client, setClient] = useState<RpcClient | null>(null);
   const [draft, setDraft] = useState("");
+  const [isDraggingWindow, setIsDraggingWindow] = useState(false);
+  const [isIdleHappy, setIsIdleHappy] = useState(false);
 
-  // Main reply bubble — only the final LLM answer, not tool status.
+  // Main reply bubble: only the final LLM answer, not tool status.
   const [replyText, setReplyText] = useState("");
   const [replyPending, setReplyPending] = useState(false);
 
-  // Separate tool status line (small, below the sprite).
+  // Separate tool status line below the sprite.
   const [toolStatus, setToolStatus] = useState("");
 
   // Auto-hide bubble after conversation ends.
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const clearHide = () => { if (hideTimer.current) { clearTimeout(hideTimer.current); hideTimer.current = null; } };
-  const scheduleHide = () => { clearHide(); hideTimer.current = setTimeout(() => { setReplyText(""); setToolStatus(""); }, 12000); };
+  const idleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clearHide = () => {
+    if (hideTimer.current) {
+      clearTimeout(hideTimer.current);
+      hideTimer.current = null;
+    }
+  };
+  const clearIdleTimer = () => {
+    if (idleTimer.current) {
+      clearTimeout(idleTimer.current);
+      idleTimer.current = null;
+    }
+  };
+  const scheduleHide = () => {
+    clearHide();
+    hideTimer.current = setTimeout(() => {
+      setReplyText("");
+      setToolStatus("");
+    }, 12000);
+  };
+  const markActive = useCallback(() => {
+    setIsIdleHappy(false);
+    clearIdleTimer();
+    idleTimer.current = setTimeout(() => {
+      setIsIdleHappy(true);
+    }, IDLE_HAPPY_DELAY_MS);
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const { getCurrentWindow } = await import("@tauri-apps/api/window");
+        const win = getCurrentWindow();
+        const saved = localStorage.getItem("windowPosition");
+        if (saved) {
+          const { x, y } = JSON.parse(saved);
+          const { PhysicalPosition } = await import("@tauri-apps/api/dpi");
+          await win.setPosition(new PhysicalPosition(x, y));
+        }
+      } catch {
+        // Ignore outside Tauri.
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    const save = async () => {
+      try {
+        const { getCurrentWindow } = await import("@tauri-apps/api/window");
+        const pos = await getCurrentWindow().outerPosition();
+        localStorage.setItem("windowPosition", JSON.stringify({ x: pos.x, y: pos.y }));
+      } catch {
+        // ignore
+      }
+    };
+    window.addEventListener("beforeunload", save);
+    return () => window.removeEventListener("beforeunload", save);
+  }, []);
+
+  useEffect(() => {
+    markActive();
+    const handlePointerUp = () => setIsDraggingWindow(false);
+    const handleActivity = () => markActive();
+
+    window.addEventListener("pointerdown", handleActivity);
+    window.addEventListener("keydown", handleActivity);
+    window.addEventListener("pointerup", handlePointerUp);
+    window.addEventListener("pointercancel", handlePointerUp);
+    window.addEventListener("blur", handlePointerUp);
+
+    return () => {
+      clearIdleTimer();
+      window.removeEventListener("pointerdown", handleActivity);
+      window.removeEventListener("keydown", handleActivity);
+      window.removeEventListener("pointerup", handlePointerUp);
+      window.removeEventListener("pointercancel", handlePointerUp);
+      window.removeEventListener("blur", handlePointerUp);
+    };
+  }, [markActive]);
 
   const handleEvent = useCallback((evt: RpcEvent) => {
     const character = useCharacterStore.getState();
@@ -46,10 +127,8 @@ export function App() {
       character.setAgentState(p.is_thinking ? "thinking" : "talking");
 
       if (p.is_thinking) {
-        // Tool status goes to the separate status line, not the bubble.
         setToolStatus((prev) => prev + (p.text ?? ""));
       } else {
-        // Actual reply goes to the bubble.
         setReplyText((prev) => prev + (p.text ?? ""));
       }
       clearHide();
@@ -73,7 +152,10 @@ export function App() {
     (async () => {
       const info: DaemonInfo | null = await resolveDaemonInfo();
       if (cancelled) return;
-      if (!info) { setStatus("closed"); return; }
+      if (!info) {
+        setStatus("closed");
+        return;
+      }
       setStatus("connecting");
       cur = createRpcClient({
         url: `ws://127.0.0.1:${info.port}/ws`,
@@ -94,7 +176,10 @@ export function App() {
       });
       setClient(cur);
     })();
-    return () => { cancelled = true; cur?.close(); };
+    return () => {
+      cancelled = true;
+      cur?.close();
+    };
   }, [setStatus, handleEvent]);
 
   const send = () => {
@@ -109,7 +194,26 @@ export function App() {
     setDraft("");
   };
 
-  const sprite = resolveSprite(agentState, emotion);
+  const startWindowDrag = useCallback(async () => {
+    setIsDraggingWindow(true);
+    markActive();
+    try {
+      const { getCurrentWindow } = await import("@tauri-apps/api/window");
+      await getCurrentWindow().startDragging();
+    } catch {
+      // Ignore outside Tauri or when permission is unavailable.
+    }
+  }, [markActive]);
+
+  const activeEmotion: Emotion = isDraggingWindow
+    ? "angry"
+    : isIdleHappy && agentState === "idle"
+      ? "happy"
+      : emotion;
+  const sprite = resolveSprite(
+    isDraggingWindow ? "idle" : agentState,
+    activeEmotion,
+  );
 
   return (
     <div
@@ -124,10 +228,20 @@ export function App() {
         overflow: "hidden",
       }}
     >
-      {/* Fixed layout: bubble at top, character in middle, input at bottom */}
-
-      {/* Reply bubble — fixed position above the character */}
-      <div style={{ height: 100, display: "flex", alignItems: "flex-end", justifyContent: "center", padding: "0 10px" }}>
+      <div
+        onMouseDown={(e) => {
+          if (e.button !== 0) return;
+          void startWindowDrag();
+        }}
+        style={{
+          height: 100,
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "center",
+          padding: "0 10px",
+          cursor: "grab",
+        }}
+      >
         {replyText ? (
           <div
             style={{
@@ -152,8 +266,19 @@ export function App() {
         ) : null}
       </div>
 
-      {/* Character sprite — fixed position, never moves */}
-      <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center" }}>
+      <div
+        onMouseDown={(e) => {
+          if (e.button !== 0) return;
+          void startWindowDrag();
+        }}
+        style={{
+          flex: 1,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          cursor: "grab",
+        }}
+      >
         {sprite && (
           <img
             src={sprite}
@@ -164,23 +289,28 @@ export function App() {
         )}
       </div>
 
-      {/* Tool status — small text below sprite, separate from bubble */}
       {toolStatus && (
-        <div style={{
-          textAlign: "center",
-          fontSize: 10,
-          opacity: 0.5,
-          fontStyle: "italic",
-          padding: "0 10px 2px",
-          whiteSpace: "nowrap",
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-        }}>
+        <div
+          onMouseDown={(e) => {
+            if (e.button !== 0) return;
+            void startWindowDrag();
+          }}
+          style={{
+            textAlign: "center",
+            fontSize: 10,
+            opacity: 0.5,
+            fontStyle: "italic",
+            padding: "0 10px 2px",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            cursor: "grab",
+          }}
+        >
           {toolStatus}
         </div>
       )}
 
-      {/* Input — fixed at bottom */}
       {status === "open" && (
         <div style={{ padding: "4px 10px 8px" }}>
           <input

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,10 @@ export function App() {
   // Auto-hide bubble after conversation ends.
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const idleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Keep the angry sprite up briefly after release so a quick drag
+  // doesn't flicker back to neutral on the same frame.
+  const dragReleaseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const DRAG_LINGER_MS = 300;
   const clearHide = () => {
     if (hideTimer.current) {
       clearTimeout(hideTimer.current);
@@ -99,7 +103,13 @@ export function App() {
 
   useEffect(() => {
     markActive();
-    const handlePointerUp = () => setIsDraggingWindow(false);
+    const handlePointerUp = () => {
+      if (dragReleaseTimer.current) clearTimeout(dragReleaseTimer.current);
+      dragReleaseTimer.current = setTimeout(() => {
+        setIsDraggingWindow(false);
+        dragReleaseTimer.current = null;
+      }, DRAG_LINGER_MS);
+    };
     const handleActivity = () => markActive();
 
     window.addEventListener("pointerdown", handleActivity);
@@ -110,6 +120,10 @@ export function App() {
 
     return () => {
       clearIdleTimer();
+      if (dragReleaseTimer.current) {
+        clearTimeout(dragReleaseTimer.current);
+        dragReleaseTimer.current = null;
+      }
       window.removeEventListener("pointerdown", handleActivity);
       window.removeEventListener("keydown", handleActivity);
       window.removeEventListener("pointerup", handlePointerUp);
@@ -195,6 +209,10 @@ export function App() {
   };
 
   const startWindowDrag = useCallback(async () => {
+    if (dragReleaseTimer.current) {
+      clearTimeout(dragReleaseTimer.current);
+      dragReleaseTimer.current = null;
+    }
     setIsDraggingWindow(true);
     markActive();
     try {

--- a/frontend/src/features/character/spriteMap.ts
+++ b/frontend/src/features/character/spriteMap.ts
@@ -6,8 +6,7 @@ import thinkImg from "./sprites/think.png";
 import surpriseImg from "./sprites/surprise.png";
 import sadImg from "./sprites/sad.png";
 import angryImg from "./sprites/angry.png";
-// happyImg is available as an extra smile variant if needed:
-// import happyImg from "./sprites/happy.png";
+import happyImg from "./sprites/happy.png";
 
 const emotionToSprite: Record<Emotion, string> = {
   neutral: neutralImg,
@@ -16,6 +15,7 @@ const emotionToSprite: Record<Emotion, string> = {
   surprise: surpriseImg,
   sad: sadImg,
   angry: angryImg,
+  happy: happyImg,
 };
 
 /**

--- a/frontend/src/store/characterStore.ts
+++ b/frontend/src/store/characterStore.ts
@@ -1,7 +1,14 @@
 import { create } from "zustand";
 
 export type AgentState = "idle" | "thinking" | "talking" | "listening" | "hidden";
-export type Emotion = "neutral" | "smile" | "think" | "surprise" | "sad" | "angry";
+export type Emotion =
+  | "neutral"
+  | "smile"
+  | "think"
+  | "surprise"
+  | "sad"
+  | "angry"
+  | "happy";
 
 interface CharacterStore {
   agentState: AgentState;


### PR DESCRIPTION
Closes #47, Closes #49

## Summary
tama さんが実装したウィンドウドラッグ移動 + アイドル/ドラッグ時の表情切り替え。古い develop から分岐していたので最新 develop (web.search / streaming TTS 入り) に rebase 済み。私 (akatuki) からは離した直後の表情リバートに 300ms の linger を追加。

## 実装内容

### #49 ウィンドウドラッグ
- `frontend/src-tauri/capabilities/default.json` 新規 (Tauri 2 の `core:window:allow-start-dragging` 権限)
- `tauri.conf.json` に `dragDropEnabled: true`
- App.tsx の吹き出し / スプライト / tool ステータス領域に `onMouseDown` → `getCurrentWindow().startDragging()`
- `@tauri-apps/api/window` を **動的 import** しているのでブラウザ / vitest 環境では何もしない (テスト維持)
- 位置を `localStorage["windowPosition"]` に保存 → 起動時に `setPosition(new PhysicalPosition(x, y))` で復元

### #47 表情変化
- `Emotion` 型に `happy` を追加 (6 → 7 種)
- spriteMap に `happy.png` 統合
- ドラッグ中は emotion を `angry` に強制 (持ち上げられて怒るかわいい挙動)
- 60 秒 idle で emotion を `happy` に (退屈してニコニコ)
- pointerdown / keydown で activity 検出して idle timer リセット
- ドラッグ離した直後に 300ms angry を keep してから戻す (一瞬の drag でも表情が見える) — 私の追加

## 検証
- pnpm typecheck 緑
- pnpm test 21 passed (動的 import なので既存テストは無影響)
- 実機 (Tauri dev) で起動確認済 — 窓ドラッグ + emotion 切替動作