### PR TITLE
fix(agent): unbounded read timeout for llama-server SSE stream

### DIFF
--- a/agent/src/agent/llm/llama_server.py
+++ b/agent/src/agent/llm/llama_server.py
@@ -33,9 +33,18 @@ class LlamaServerBackend:
         self._transport = transport
 
     def _make_client(self) -> httpx.AsyncClient:
+        # Streaming SSE: connect/write/pool stay bounded, but read=None so a
+        # slow first token (cold model load, large prompt eval on weak HW)
+        # doesn't trip ReadTimeout. timeout_s still caps connect/write/pool.
+        timeout = httpx.Timeout(
+            connect=self.timeout_s,
+            read=None,
+            write=self.timeout_s,
+            pool=self.timeout_s,
+        )
         if self._transport is not None:
-            return httpx.AsyncClient(transport=self._transport, timeout=self.timeout_s)
-        return httpx.AsyncClient(timeout=self.timeout_s)
+            return httpx.AsyncClient(transport=self._transport, timeout=timeout)
+        return httpx.AsyncClient(timeout=timeout)
 
     async def chat_stream(
         self,

--- a/agent/tests/test_llama_server_backend.py
+++ b/agent/tests/test_llama_server_backend.py
@@ -100,6 +100,15 @@ async def test_reasoning_content_field_is_routed_to_thinking_buffer() -> None:
     assert "".join(main) == "final answer"
 
 
+def test_streaming_client_has_unbounded_read_timeout() -> None:
+    # Regression guard: a single float passed to httpx.AsyncClient applies
+    # to read too, which kills long-TTFT cold-start streams.
+    backend = LlamaServerBackend(base_url="http://test", timeout_s=5.0)
+    client = backend._make_client()
+    assert client.timeout.read is None
+    assert client.timeout.connect == 5.0
+
+
 @pytest.mark.asyncio
 async def test_done_sentinel_terminates_stream() -> None:
     body = _sse_lines(


### PR DESCRIPTION
## Summary
- `httpx.AsyncClient(timeout=60.0)` applied 60s to **read** as well, so a slow first token (cold model load, big prompt eval on weak HW / CPU fallback) tripped `ReadTimeout` mid-stream — surfaced as the traceback another team member hit.
- Split the timeouts: `connect`/`write`/`pool` stay bounded by `timeout_s`, `read=None` lets SSE chunks arrive at their own pace.
- Added a regression test guarding against re-introducing the single-float form.

## Reproduction
Verified end-to-end against a real local Starlette SSE server with a 2.5s first-chunk delay and `timeout_s=1.0`:
- **before:** `httpx.ReadTimeout('')` (same exception class as the original stack)
- **after:** stream completes, content assembled correctly

## Test plan
- [x] `uv run pytest` — 49 passed, 1 skipped (live llama-server, env-gated)
- [x] new test `test_streaming_client_has_unbounded_read_timeout` asserts `client.timeout.read is None` and `connect == timeout_s`
- [x] manual repro with delayed local SSE server confirms the bug pre-fix and the green path post-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)