### PR TITLE
feat(frontend): 吹き出しデザイン更新 + 入力プレビュー

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,15 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>desktop-ai-agent</title>
+    <style>
+      .typing-cursor {
+        animation: blink 0.8s step-end infinite;
+        color: #86c166;
+      }
+      @keyframes blink {
+        50% { opacity: 0; }
+      }
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,8 @@ export function App() {
   // Separate tool status line below the sprite.
   const [toolStatus, setToolStatus] = useState("");
 
+  const [lastUserText, setLastUserText] = useState("");
+
   // Auto-hide bubble after conversation ends.
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const idleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -60,6 +62,7 @@ export function App() {
     hideTimer.current = setTimeout(() => {
       setReplyText("");
       setToolStatus("");
+      setLastUserText("");
     }, 12000);
   };
   const markActive = useCallback(() => {
@@ -205,6 +208,7 @@ export function App() {
     clearHide();
     useCharacterStore.getState().setAgentState("thinking");
     client.send("session.send_text", { text });
+    setLastUserText(text);
     setDraft("");
   };
 
@@ -246,6 +250,27 @@ export function App() {
         overflow: "hidden",
       }}
     >
+      {lastUserText && (replyText || replyPending) && (
+        <div
+          onMouseDown={(e) => {
+            if (e.button !== 0) return;
+            void startWindowDrag();
+          }}
+          style={{
+            fontSize: 10,
+            color: "rgba(0,0,0,0.4)",
+            marginBottom: 4,
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            maxWidth: 240,
+            padding: "0 10px",
+            cursor: "grab",
+          }}
+        >
+          {">"} {lastUserText}
+        </div>
+      )}
       <div
         onMouseDown={(e) => {
           if (e.button !== 0) return;
@@ -260,6 +285,7 @@ export function App() {
           cursor: "grab",
         }}
       >
+
         {replyText ? (
           <div
             style={{
@@ -269,18 +295,26 @@ export function App() {
               padding: "6px 10px",
               borderRadius: 10,
               background: "rgba(255,255,255,0.95)",
-              border: "1px solid rgba(0,0,0,0.1)",
-              boxShadow: "0 2px 6px rgba(0,0,0,0.06)",
+              border: "2px solid #86c166",  // ずんだもんカラー (緑)
+              boxShadow: "0 2px 8px rgba(134,193,102,0.15)",
               fontSize: 12,
               lineHeight: 1.5,
-              wordBreak: "break-word",
-              opacity: replyPending ? 0.8 : 1,
+              wordBreak: "break-word" as const,
+              position: "relative" as const,
             }}
           >
             {replyText}
+            <div style={{
+              width: 0,
+              height: 0,
+              borderLeft: "8px solid transparent",
+              borderRight: "8px solid transparent",
+              borderTop: "8px solid #86c166",
+              margin: "0 auto",
+            }} />
           </div>
         ) : replyPending ? (
-          <div style={{ fontSize: 11, opacity: 0.5 }}>...</div>
+           <span className="typing-cursor">▍</span>
         ) : null}
       </div>
 


### PR DESCRIPTION
## Summary
- 返信ふきだしを白背景＋ずんだもんカラー (#86c166) の枠＋下向き三角に更新
- ふきだし上に直前のユーザ入力を `> ...` で 1 行プレビュー表示（返信中のみ）
- 待機中カーソル `▍` を `typing-cursor` クラスで点滅 (CSS keyframes)
- `scheduleHide` で `lastUserText` も併せてクリア

## Notes
- 元ブランチが `0018064` 起点だったため、現 `develop` (streaming TTS / window drag / read-timeout fix を含む) に rebase 済み。
- Conflict 解決方針: develop 側の機能 (idle/drag タイマー、ウィンドウ位置保存) は全部維持。response 側の追加 (`scheduleHide` での `lastUserText` クリア + 入力プレビュー) を取り込み。プレビュー部分にも window-drag の `onMouseDown` を付けて、見た目が変わってもドラッグ可能領域が縮まないようにした。

## Test plan
- [x] `pnpm typecheck` (tsc -b --noEmit) PASS
- [x] `pnpm test` (vitest) — 21 passed (Bubble.test.tsx 含む)
- [x] 実機動作確認: agent daemon + vite dev を立ち上げ、ブラウザでメッセージ送信 → ふきだし表示・プレビュー・自動非表示を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)